### PR TITLE
generalize ax25 preprocessor

### DIFF
--- a/scripts/beacon_rtl_sdr.py
+++ b/scripts/beacon_rtl_sdr.py
@@ -26,12 +26,15 @@ parser.add_argument("-p", "--print", dest="print", action="store_true",
 args = parser.parse_args()
 
 
-def send_packet(packet):
+def send_packet(message):
     # get the TNC command. We only support 0x00 data from
-    cmd = packet[0]
+    cmd = message[0]
     if cmd != 0:
         print("Unknown command: {}".format(str(cmd)))
         return
+
+    # remove added TNC command
+    packet = message[1:]
 
     if args.print:
         print(packet)

--- a/scripts/beacon_rtl_sdr.py
+++ b/scripts/beacon_rtl_sdr.py
@@ -5,7 +5,7 @@ Linux package dependencies:
     rtl-sdr direwolf
 
 Python library dependencies:
-    kiss bitstring
+    kiss
 """
 
 import time
@@ -14,7 +14,6 @@ import subprocess
 import sys
 import socket
 import kiss
-import bitstring
 
 # start the rtl_fm and direwolf commands
 rtl_fm_args = ["rtl_fm", "-Mfm", "-f436.5M", "-p48.1", "-s96000", "-g30", "-"]
@@ -31,16 +30,8 @@ def send_packet(x):
         print("Unknown command: {}".format(str(cmd)))
         return
 
-    # decode the 14 byte address fields with the callsigned and SSIDs. The
-    # field is encoded shifted 1 but to the left, so shift it it to the right>
-    addr = x[1:15]
-    addr = (bitstring.BitArray(addr) >> 1).bytes
-
-    # readd the control and PID bytes
-    addr = addr + x[15:16] + x[16:17]
-
     # send fixed message
-    tm_socket.sendto(addr + x[17:], ('127.0.0.1', 10015))
+    tm_socket.sendto(x, ('127.0.0.1', 10015))
 
 
 def read_kiss_forever():

--- a/scripts/beacon_scs.py
+++ b/scripts/beacon_scs.py
@@ -7,12 +7,18 @@ Python library dependencies:
 
 import sys
 import socket
+from argparse import ArgumentParser
 
 from serial import Serial, SerialException
 import bitstring
 
 TTY = '/dev/serial/by-id/usb-SCS_SCS_Tracker___DSP_TNC_PT2HJ743-if00-port0'
 BEACON_LEN = 242
+
+parser = ArgumentParser(description="OLM file transfer")
+parser.add_argument("-p", "--print", dest="print", action="store_true",
+                    help="print messages to stdout")
+args = parser.parse_args()
 
 
 def _readline(ser: Serial):
@@ -69,6 +75,9 @@ def send_tm(ser: Serial):
         # merge header and payload together
         # remove the \r\n
         packet = packet_header + message[:len(message)-2]
+
+        if args.print:
+            print(packet)
 
         tm_socket.sendto(packet, ('127.0.0.1', 10015))
 

--- a/scripts/beacon_scs.py
+++ b/scripts/beacon_scs.py
@@ -2,12 +2,14 @@
 """Send C3 beacon to Yamcs from SCS
 
 Python library dependencies:
-    serial
+    bitstring serial
 """
 
 import sys
 import socket
+
 from serial import Serial, SerialException
+import bitstring
 
 TTY = '/dev/serial/by-id/usb-SCS_SCS_Tracker___DSP_TNC_PT2HJ743-if00-port0'
 BEACON_LEN = 242
@@ -42,6 +44,8 @@ def send_tm(ser: Serial):
     packet_header = dest.encode() + dest_ssid.to_bytes(1, 'little') + \
         src.encode() + src_ssid.to_bytes(1, 'little') + \
         control.to_bytes(1, 'little') + sid.to_bytes(1, 'little')
+
+    packet_header = (bitstring.BitArray(packet_header) << 1).bytes
 
     while True:
         message = b''

--- a/scripts/beacon_simulator.py
+++ b/scripts/beacon_simulator.py
@@ -11,8 +11,14 @@ import socket
 import sys
 from threading import Thread
 from time import sleep
+from argparse import ArgumentParser
 
 import bitstring
+
+parser = ArgumentParser(description="OLM file transfer")
+parser.add_argument("-p", "--print", dest="print", action="store_true",
+                    help="print messages to stdout")
+args = parser.parse_args()
 
 
 def send_tm(simulator):
@@ -36,6 +42,10 @@ def send_tm(simulator):
         packet_data = bytearray(os.urandom(238))
         calc_crc = binascii.crc32(packet_data)
         packet = packet_header + packet_data + calc_crc.to_bytes(4, 'little')
+
+        if args.print:
+            print("")
+            print(packet)
 
         tm_socket.sendto(packet, ('127.0.0.1', 10015))
         simulator.tm_counter += 1

--- a/scripts/beacon_simulator.py
+++ b/scripts/beacon_simulator.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
-"""Generate C3 beacons and send to Yamcs"""
+"""Generate C3 beacons and send to Yamcs
+
+Python library dependencies:
+    bitstring
+"""
 
 import binascii
 import os
@@ -7,6 +11,8 @@ import socket
 import sys
 from threading import Thread
 from time import sleep
+
+import bitstring
 
 
 def send_tm(simulator):
@@ -17,12 +23,13 @@ def send_tm(simulator):
     src = "KJ7SAT"
     src_ssid = 0
     control = 0
-    sid = 0
+    pid = 0
 
     packet_header = dest.encode() + dest_ssid.to_bytes(1, 'little') + \
         src.encode() + src_ssid.to_bytes(1, 'little') + \
-        control.to_bytes(1, 'little') + sid.to_bytes(1, 'little')
-    print(len(packet_header))
+        control.to_bytes(1, 'little') + pid.to_bytes(1, 'little')
+
+    packet_header = (bitstring.BitArray(packet_header) << 1).bytes
 
     simulator.tm_counter = 1
     while True:

--- a/src/main/yamcs/etc/yamcs.oresat0.yaml
+++ b/src/main/yamcs/etc/yamcs.oresat0.yaml
@@ -26,7 +26,10 @@ dataLinks:
     class: org.yamcs.tctm.UdpTmDataLink
     stream: tm_realtime
     port: 10015
-    packetPreprocessorClassName: org.oresat.uniclogs.AprsPacketPreprocessor
+    packetPreprocessorClassName: org.oresat.uniclogs.Ax25PacketPreprocessor
+    packetPreprocessorArgs:
+      destCallsign: "SPACE"
+      srcCallsign: "KJ7SAT"
 
   - name: uniclogs-out
     class: org.yamcs.tctm.UdpTcDataLink


### PR DESCRIPTION
This generalize the ax25 preprocessor so the source and destination callsigns can be configure. 

If one or both callsigns are set in the configuration, the packet header will be checked for matching callsigns. If the callsign(s) do not match, the packet will be ignored.

closes #2 