### PR TITLE
remove security config

### DIFF
--- a/src/main/yamcs/etc/security.yaml
+++ b/src/main/yamcs/etc/security.yaml
@@ -1,2 +1,0 @@
-authModules:
-  - class: org.yamcs.security.DirectoryAuthModule


### PR DESCRIPTION
The security config is only needed on the production environment not in the source code.