### PR TITLE
Yamcs Core Framework update to 5.10.9

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -1,0 +1,22 @@
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        cache: 'maven'
+    - name: Download and Verify Package Dependencies
+      run: mvn --batch-mode --update-snapshots verify
+    - name: Run Unit Tests
+      run: mvn test
+    - name: Package Yamcs
+      run: mvn clean package

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     Update this to the latest Yamcs release.
     Check https://mvnrepository.com/artifact/org.yamcs/yamcs-core
     -->
-    <yamcsVersion>5.6.0</yamcsVersion>
+    <yamcsVersion>5.10.9</yamcsVersion>
   </properties>
 
   <dependencies>

--- a/src/main/yamcs/etc/yamcs.oresat0.yaml
+++ b/src/main/yamcs/etc/yamcs.oresat0.yaml
@@ -55,7 +55,6 @@ dataLinks:
   - name: edl-tm-realtime
     class: org.yamcs.tctm.UdpTmDataLink
     stream: edl_tm_realtime
-    host: localhost
     port: 10016
     packetPreprocessorClassName: org.oresat.uniclogs.tctm.EdlPacketPreprocessor
 


### PR DESCRIPTION
Updated Yamcs Core framework to `v5.10.9`.

# Basic checkout was as follows:

1. Update POM version
2. Re-pull maven dependencies
3. `$` `mvn clean yamcs:debug`

***

# Results were as follows:

![yamcs](https://github.com/user-attachments/assets/7e88cfa0-3c98-489b-b4ea-02dc7adb9f0b)

```
Feb 02, 2025 6:17:32 PM org.yamcs.logging.Log log
INFO: Logging enabled using /home/dmitri/repos/uniclogs/yamcs/target/yamcs/etc/logging.properties
Feb 02, 2025 6:17:32 PM org.yamcs.logging.Log log
INFO: Loading service UniclogsServer
Feb 02, 2025 6:17:32 PM org.yamcs.logging.Log log
INFO: Creating or loading tablespace _global
Feb 02, 2025 6:17:32 PM org.yamcs.logging.Log log
INFO: Creating database at data-dir/_global.rdb
Feb 02, 2025 6:17:32 PM org.yamcs.logging.Log log
INFO: Loaded 0 tables for instance _global
Feb 02, 2025 6:17:32 PM org.yamcs.logging.Log log
INFO: Started UniclogsServer:null with config: {port=8090, contextPath=, zeroCopyEnabled=true, maxInitialLineLength=8192, maxHeaderSize=8192, maxContentLength=65536, maxPageSize=1000, webSocket={writeBufferWaterMark={low=32768, high=131072}, maxFrameLength=65536, pingWhenIdleFor=40}, nThreads=0, reverseLookup=false} from: /home/dmitri/repos/uniclogs/yamcs/target/yamcs/etc
Feb 02, 2025 6:17:32 PM org.yamcs.logging.Log log
INFO: Created new protobuf db tbsIndex: 5
Feb 02, 2025 6:17:33 PM org.yamcs.logging.Log log
INFO: Saving new user [name=admin, id=6]
Feb 02, 2025 6:17:33 PM org.yamcs.logging.Log log
INFO: Loading online instance 'oresat0'
Feb 02, 2025 6:17:33 PM org.yamcs.xtce.xml.XtceStaxReader readXmlDocument
INFO: Parsing XTCE file mdb/oresat.xml
Feb 02, 2025 6:17:33 PM org.yamcs.xtce.xml.XtceStaxReader skipXtceSection
INFO: Section <AuthorSet> skipped
Feb 02, 2025 6:17:33 PM org.yamcs.xtce.xml.XtceStaxReader readXmlDocument
INFO: XTCE file parsing finished, loaded: 21 parameters, 4 tm containers, 1 commands
Feb 02, 2025 6:17:33 PM org.yamcs.xtce.xml.XtceStaxReader readXmlDocument
INFO: Parsing XTCE file mdb/batterypack.xml
Feb 02, 2025 6:17:33 PM org.yamcs.xtce.xml.XtceStaxReader skipXtceSection
INFO: Section <AuthorSet> skipped
Feb 02, 2025 6:17:33 PM org.yamcs.xtce.xml.XtceStaxReader readXmlDocument
INFO: XTCE file parsing finished, loaded: 19 parameters, 1 tm containers, 0 commands
Feb 02, 2025 6:17:33 PM org.yamcs.xtce.xml.XtceStaxReader readXmlDocument
INFO: Parsing XTCE file mdb/batterypack.xml
Feb 02, 2025 6:17:33 PM org.yamcs.xtce.xml.XtceStaxReader skipXtceSection
INFO: Section <AuthorSet> skipped
Feb 02, 2025 6:17:33 PM org.yamcs.xtce.xml.XtceStaxReader readXmlDocument
INFO: XTCE file parsing finished, loaded: 19 parameters, 1 tm containers, 0 commands
Feb 02, 2025 6:17:33 PM org.yamcs.xtce.xml.XtceStaxReader readXmlDocument
INFO: Parsing XTCE file mdb/c3.xml
Feb 02, 2025 6:17:33 PM org.yamcs.xtce.xml.XtceStaxReader skipXtceSection
INFO: Section <AuthorSet> skipped
Feb 02, 2025 6:17:33 PM org.yamcs.xtce.xml.XtceStaxReader readXmlDocument
INFO: XTCE file parsing finished, loaded: 15 parameters, 1 tm containers, 13 commands
Feb 02, 2025 6:17:33 PM org.yamcs.xtce.xml.XtceStaxReader readXmlDocument
INFO: Parsing XTCE file mdb/solar.xml
Feb 02, 2025 6:17:33 PM org.yamcs.xtce.xml.XtceStaxReader skipXtceSection
INFO: Section <AuthorSet> skipped
Feb 02, 2025 6:17:33 PM org.yamcs.xtce.xml.XtceStaxReader readXmlDocument
INFO: XTCE file parsing finished, loaded: 28 parameters, 1 tm containers, 0 commands
Feb 02, 2025 6:17:33 PM org.yamcs.xtce.xml.XtceStaxReader readXmlDocument
INFO: Parsing XTCE file mdb/startracker.xml
Feb 02, 2025 6:17:33 PM org.yamcs.xtce.xml.XtceStaxReader skipXtceSection
INFO: Section <AuthorSet> skipped
Feb 02, 2025 6:17:33 PM org.yamcs.xtce.xml.XtceStaxReader readXmlDocument
INFO: XTCE file parsing finished, loaded: 8 parameters, 1 tm containers, 0 commands
Feb 02, 2025 6:17:33 PM org.yamcs.xtce.xml.XtceStaxReader readXmlDocument
INFO: Parsing XTCE file mdb/gps.xml
Feb 02, 2025 6:17:33 PM org.yamcs.xtce.xml.XtceStaxReader skipXtceSection
INFO: Section <AuthorSet> skipped
Feb 02, 2025 6:17:33 PM org.yamcs.xtce.xml.XtceStaxReader readXmlDocument
INFO: XTCE file parsing finished, loaded: 14 parameters, 1 tm containers, 0 commands
Feb 02, 2025 6:17:33 PM org.yamcs.xtce.xml.XtceStaxReader readXmlDocument
INFO: Parsing XTCE file mdb/dxwifi.xml
Feb 02, 2025 6:17:33 PM org.yamcs.xtce.xml.XtceStaxReader skipXtceSection
INFO: Section <AuthorSet> skipped
Feb 02, 2025 6:17:33 PM org.yamcs.xtce.xml.XtceStaxReader readXmlDocument
INFO: XTCE file parsing finished, loaded: 6 parameters, 1 tm containers, 0 commands
Feb 02, 2025 6:17:33 PM org.yamcs.logging.Log log
INFO: Serialized database saved locally
Feb 02, 2025 6:17:33 PM org.yamcs.logging.Log log
INFO: Creating or loading tablespace oresat0
Feb 02, 2025 6:17:33 PM org.yamcs.logging.Log log
INFO: Creating database at data-dir/oresat0.rdb
Feb 02, 2025 6:17:33 PM org.yamcs.logging.Log log
INFO: Loaded 0 tables for instance oresat0
Feb 02, 2025 6:17:33 PM org.yamcs.logging.Log log
INFO: Loading service UniclogsEnvironment
Feb 02, 2025 6:17:33 PM org.yamcs.logging.Log log
INFO: Loading service XtceTmRecorder
Feb 02, 2025 6:17:33 PM org.yamcs.logging.Log log
INFO: Loading service ParameterRecorder
Feb 02, 2025 6:17:33 PM org.yamcs.logging.Log log
INFO: Loading service AlarmRecorder
Feb 02, 2025 6:17:33 PM org.yamcs.logging.Log log
INFO: Loading service EventRecorder
Feb 02, 2025 6:17:33 PM org.yamcs.logging.Log log
INFO: Loading service ReplayServer
Feb 02, 2025 6:17:33 PM org.yamcs.logging.Log log
INFO: Loading service SystemParametersService
Feb 02, 2025 6:17:33 PM org.yamcs.Spec$Option validate
WARNING: Argument provideJvmVariables has been deprecated: This option is obsolete, please add 'jvm' to the list of producers
Feb 02, 2025 6:17:33 PM org.yamcs.Spec$Option validate
WARNING: Argument provideFsVariables has been deprecated: This option is obsolete, please add 'fs' to the list of producers
Feb 02, 2025 6:17:33 PM org.yamcs.logging.Log log
INFO: Loading service ProcessorCreatorService
Feb 02, 2025 6:17:33 PM org.yamcs.logging.Log log
INFO: Loading service CommandHistoryRecorder
Feb 02, 2025 6:17:33 PM org.yamcs.logging.Log log
INFO: Loading service ParameterArchive
Feb 02, 2025 6:17:33 PM org.yamcs.logging.Log log
INFO: HMAC_KEY
Feb 02, 2025 6:17:33 PM org.yamcs.logging.Log log
INFO: Env not found for oresat0, creating new env...
Feb 02, 2025 6:17:33 PM org.yamcs.logging.Log log
INFO: Loading processor service StreamTmPacketProvider
Feb 02, 2025 6:17:33 PM org.yamcs.logging.Log log
INFO: Loading processor service StreamTcCommandReleaser
Feb 02, 2025 6:17:33 PM org.yamcs.logging.Log log
INFO: Loading processor service StreamParameterProvider
Feb 02, 2025 6:17:33 PM org.yamcs.logging.Log log
INFO: Loading processor service AlgorithmManager
Feb 02, 2025 6:17:33 PM org.yamcs.logging.Log log
INFO: Loading processor service LocalParameterManager
Feb 02, 2025 6:17:33 PM org.yamcs.logging.Log log
INFO: Creating new processor 'realtime' of type 'realtime'
Feb 02, 2025 6:17:33 PM org.yamcs.logging.Log log
INFO: Yamcs 5.10.9, build 746c6a4f0584a68f11125cccc1d4de512796242e
Feb 02, 2025 6:17:33 PM org.yamcs.logging.Log log
INFO: Hmac Key not in oresat0. Loading from env var: HMAC_KEY
Feb 02, 2025 6:17:33 PM org.yamcs.logging.Log log
INFO: Sequence Number not found for oresat0, Sequence Number set to 1
Feb 02, 2025 6:17:33 PM org.yamcs.logging.Log log
INFO: Loaded Sequence Number: 1
Feb 02, 2025 6:17:33 PM org.yamcs.logging.Log log
INFO: Awaiting start of service UniclogsEnvironment
Feb 02, 2025 6:17:33 PM org.yamcs.logging.Log log
INFO: Awaiting start of service XtceTmRecorder
Feb 02, 2025 6:17:33 PM org.yamcs.logging.Log log
INFO: Awaiting start of service ParameterRecorder
Feb 02, 2025 6:17:33 PM org.yamcs.logging.Log log
INFO: Awaiting start of service AlarmRecorder
Feb 02, 2025 6:17:33 PM org.yamcs.logging.Log log
INFO: Awaiting start of service EventRecorder
Feb 02, 2025 6:17:33 PM org.yamcs.logging.Log log
INFO: Awaiting start of service ReplayServer
Feb 02, 2025 6:17:33 PM org.yamcs.logging.Log log
INFO: Awaiting start of service SystemParametersService
Feb 02, 2025 6:17:33 PM org.yamcs.logging.Log log
INFO: Awaiting start of service ProcessorCreatorService
Feb 02, 2025 6:17:33 PM org.yamcs.logging.Log log
INFO: Awaiting start of service CommandHistoryRecorder
Feb 02, 2025 6:17:33 PM org.yamcs.logging.Log log
INFO: Awaiting start of service ParameterArchive
Feb 02, 2025 6:17:33 PM org.yamcs.logging.Log log
INFO: Yamcs started in 1257ms. Started 1 of 1 instances and 11 services
Feb 02, 2025 6:17:33 PM org.yamcs.logging.Log log
INFO: Website deployed at http://localhost:8090
Feb 02, 2025 6:17:36 PM org.yamcs.logging.Log log
INFO: Yamcs is shutting down
Feb 02, 2025 6:17:36 PM org.yamcs.logging.Log log
INFO: Awaiting termination of link beacon-tm-realtime
Feb 02, 2025 6:17:36 PM org.yamcs.logging.Log log
INFO: Awaiting termination of link edl-tc-realtime
Feb 02, 2025 6:17:36 PM org.yamcs.logging.Log log
INFO: Awaiting termination of link edl-tm-realtime
Feb 02, 2025 6:17:36 PM org.yamcs.logging.Log log
INFO: Awaiting termination of link beacon-tm-dump
Feb 02, 2025 6:17:36 PM org.yamcs.logging.Log log
INFO: Awaiting termination of service AlarmRecorder
Feb 02, 2025 6:17:36 PM org.yamcs.logging.Log log
INFO: Awaiting termination of service ReplayServer
Feb 02, 2025 6:17:36 PM org.yamcs.logging.Log log
INFO: Awaiting termination of service XtceTmRecorder
Feb 02, 2025 6:17:36 PM org.yamcs.logging.Log log
INFO: Awaiting termination of service EventRecorder
Feb 02, 2025 6:17:36 PM org.yamcs.logging.Log log
INFO: Shutting down, writing all pending segments
Feb 02, 2025 6:17:36 PM org.yamcs.logging.Log log
INFO: Processor realtime quitting
Feb 02, 2025 6:17:36 PM org.yamcs.logging.Log log
INFO: Awaiting termination of service ParameterRecorder
Feb 02, 2025 6:17:36 PM org.yamcs.logging.Log log
INFO: Awaiting termination of service SystemParametersService
Feb 02, 2025 6:17:36 PM org.yamcs.logging.Log log
INFO: Awaiting termination of service UniclogsEnvironment
Feb 02, 2025 6:17:36 PM org.yamcs.logging.Log log
INFO: Awaiting termination of service CommandHistoryRecorder
Feb 02, 2025 6:17:36 PM org.yamcs.logging.Log log
INFO: Processor realtime is out of business
Feb 02, 2025 6:17:36 PM org.yamcs.logging.Log log
INFO: Awaiting termination of service ProcessorCreatorService
Feb 02, 2025 6:17:36 PM org.yamcs.logging.Log log
INFO: Awaiting termination of service ParameterArchive
Feb 02, 2025 6:17:36 PM org.yamcs.logging.Log log
INFO: Stopping Yamcs DB
Feb 02, 2025 6:17:36 PM org.yamcs.logging.Log log
INFO: Stopped instance 'oresat0'
Feb 02, 2025 6:17:36 PM org.yamcs.logging.Log log
INFO: Awaiting termination of service UniclogsServer
Feb 02, 2025 6:17:36 PM org.yamcs.logging.Log log
INFO: Yamcs stopped in 30ms
```

All of the links performed bringup successfully and logs indicate no errors or warnings.
