### PR TITLE
fix issue in README referring to invalid dockerhub image

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ A custom deployment of [Yamcs] for the UniClOGS network.
 
 ## Pull the development image from Dockerhub:
 
-`docker pull oresat/uniclogs-yamcs:dev`
+`docker pull oresat/yamcs:dev`
 
 &nbsp;
 


### PR DESCRIPTION
According to the README, the command to pull down the image is: `docker pull oresat/uniclogs-yamcs:dev`

When doing this I got the following error:

```bash
$ docker pull oresat/uniclogs-yamcs:dev
Error response from daemon: pull access denied for oresat/uniclogs-yamcs, repository does not exist or may require 'docker login': denied: requested access to the resource is denied
```

This PR corrects what I believe to be the right image that lives here:
https://hub.docker.com/r/oresat/yamcs

```bash
docker pull oresat/yamcs:dev
```